### PR TITLE
bump excon and json versions

### DIFF
--- a/numverify.gemspec
+++ b/numverify.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency('excon', '~> 0.71.0')
-  spec.add_dependency('json', '~> 2.3')
+  spec.add_dependency('excon', '~> 0.91.0')
+  spec.add_dependency('json', '~> 2.6.1')
 
   spec.add_development_dependency('pry')
   spec.add_development_dependency('rake')


### PR DESCRIPTION
bumping versions because they dont play nice with chronogolf/lightspeed_restaurant
